### PR TITLE
Fixes jenkinsfile tool names

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,8 +19,8 @@
  */
 
 def AGENT_LABEL = env.AGENT_LABEL ?: 'ubuntu'
-def JDK_NAME = env.JDK_NAME ?: 'JDK 11 (latest)'
-def MAVEN_NAME = 'Maven 3 (latest)'
+def JDK_NAME = env.JDK_NAME ?: 'jdk_11_latest'
+def MAVEN_NAME = 'maven_3_latest'
 
 pipeline {
 


### PR DESCRIPTION
@chibenwa this should fix the builds for staging

I think it might be a good idea to change the default branch of the project so that PRs are opened on staging by default 

If my analysis is correct, the branches work as follow: 
* staging contains the latest site sources, once built it is deployed to asf-staging 
* live is supposed to contain the sources for the production site, once built the content  would be deployed to asf-site but that's not setup yet (and I think at the moment both staging and live are deployed to asf-staging) 

staging is a bit ahead of live at the moment so proper workflow at the moment would be: 
PR to staging, then merge staging to live 

once I understand all this a bit better I might propose a revised workflow