### PR TITLE
JAMES-3226 Fix .asf.yaml: Invalid notification target 'site-dev@james…

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,7 +18,7 @@ github:
     - smtp
     - jmap
 notifications:
-  commits:      site-dev@james.apache.org
-  issues:       site-dev@james.apache.org
-  pullrequests: site-dev@james.apache.org
+  commits:      notifications@james.apache.org
+  issues:       notifications@james.apache.org
+  pullrequests: notifications@james.apache.org
   jira_options: link label worklog


### PR DESCRIPTION
….apache.org'

Must be a valid @james.apache.org list!