### PR TITLE
Improve james-site readme

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,0 +1,37 @@
+= Contributing
+
+This repository is part of https://james.apache.org/[Apache James] project.
+
+The sources are available here https://gitbox.apache.org/repos/asf#james and mirrored to Github.
+
+This repository contains 4 branches with specific roles: 
+
+- `asf-site` contains the files which are effectively deployed to `https://james.apache.org`
+- `asf-staging` contains the files which are deployed to `https://james.staged.apache.org`
+- `live` is automatically built by a job one the [CI server](https://builds.apache.org/job/james/job/ApacheJames-Website/job/live/)
+- `staging` is automatically built by a job one the [CI server](https://builds.apache.org/job/james/job/ApacheJames-Website/job/live/)
+
+Content pushed to `asf-site` and `asf-staging` is automatically published by
+an ASF process akin to github or gitlab pages. This process can be configured
+using the [.asf.yaml](https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features)
+file.
+
+The output of the `staging` branch build is pushed to the `asf-staging` branch,
+by the CI job and thus is automatically deployed to https://james.staged.apache.org/.
+
+The output of the `live` branch build is ultimately meant to be pushed to the 
+`asf-site` branch by the corresponding CI job and thus will automatically be
+deployed to https://james.apache.org/.
+
+However at the time of this writing, the documentation website is being reorganized and 
+migrated to antora. Thus the link between `live` and `asf-site` is not enabled yet but it 
+is the target.
+
+PRs to this repository should generally target the `staging` branch.
+
+= LICENSING  
+
+The website must not be published as Apache Source files.
+The reason is the antora ui-bundle uses MPL 2.0 license and we can't mix it with ASF 2.0
+ https://issues.apache.org/jira/browse/LEGAL-530 .
+

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -9,7 +9,7 @@ This repository contains 4 branches with specific roles:
 - `asf-site` contains the files which are effectively deployed to `https://james.apache.org`
 - `asf-staging` contains the files which are deployed to `https://james.staged.apache.org`
 - `live` is automatically built by a job one the [CI server](https://builds.apache.org/job/james/job/ApacheJames-Website/job/live/)
-- `staging` is automatically built by a job one the [CI server](https://builds.apache.org/job/james/job/ApacheJames-Website/job/live/)
+- `staging` is automatically built by a job one the [CI server](https://builds.apache.org/job/james/job/ApacheJames-Website/job/staging/)
 
 Content pushed to `asf-site` and `asf-staging` is automatically published by
 an ASF process akin to github or gitlab pages. This process can be configured
@@ -31,7 +31,7 @@ PRs to this repository should generally target the `staging` branch.
 
 = LICENSING  
 
-The website must not be published as Apache Source files.
+The website must not be published as Apache Release.
 The reason is the antora ui-bundle uses MPL 2.0 license and we can't mix it with ASF 2.0
  https://issues.apache.org/jira/browse/LEGAL-530 .
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,14 +1,1 @@
-= Apache James website
-
-This repository is part of https://james.apache.org/[Apache James] project.
-
-The sources are available here https://gitbox.apache.org/repos/asf#james and mirrored to Github.
-
-This repository is used for storing (some) content for https://james.apache.org[Apache James] website.
-
-It's also used to build and publish the website.
-
-Please see https://james.apache.org/james-site/latest/index.html[online documentation website] or the `docs/` folder.
-
-IMPORTANT: The website must not be published as Apache Source files.
-The reason is the antora ui-bundle uses MPL 2.0 license and we can't mix it with ASF 2.0 https://issues.apache.org/jira/browse/LEGAL-530 .
+docs/modules/ROOT/pages/index.adoc

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -2,7 +2,7 @@
 
 This repository is used for storing (some) content for https://james.apache.org[Apache James] website.
 
-It's also used to build and publish the website. foo
+It's also used to build and publish the website.
 
 
 == How to build the website

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -2,7 +2,7 @@
 
 This repository is used for storing (some) content for https://james.apache.org[Apache James] website.
 
-It's also used to build and publish the website.
+It's also used to build and publish the website. foo
 
 
 == How to build the website


### PR DESCRIPTION
I found it pretty difficult to locate the important steps to build the repository and what the various branche were about. I therefore propose this PR which reorganizes the code and documents my findings

One downside it that it changes README.adoc to be a symbolic link to docs/module/ROOT/index.adoc. On current machines it should work on all OSes since even windows supports symbolic links but I haven't tried it. 

Unfortunately github doesn't support [adoc include directives](https://github.com/github/markup/issues/1095) and I was unable to make antora resolve the README (but maybe it can be done)