### PR TITLE
Add ASF YAML file to publish the website

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,3 @@
+publish:
+  whoami: asf-site
+  subdir: content


### PR DESCRIPTION
We received the following notice:

**Re: [NOTICE] Git web site publishing to be done via .asf.yaml only as of July 1st**

```
Gentle reminder for affected projects(BCC'ed on this email): As you have 
not yet switched to .asf.yaml for web site publishing, your project web 
site *will go stale* and not update when you push new content to its 
repository.

Please see the original email for more instructions on how to remedy this.
```

https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-WebSiteDeploymentServiceforGitRepositories